### PR TITLE
Add a GitHub Action to run codespell and ruff

### DIFF
--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -1,0 +1,19 @@
+# This Action uses minimal steps to run in ~5 seconds to rapidly:
+# look for typos in the codebase using codespell, and
+# lint Python code using ruff and provide intuitive GitHub Annotations to contributors.
+# https://github.com/codespell-project/codespell#readme
+# https://github.com/astral-sh/ruff
+name: codespell_and_ruff
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  codespell_and_ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: pip install --user codespell[toml] ruff
+    - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock,*.po"
+    - run: ruff --output-format=github --target-version=py38 .

--- a/neat/population.py
+++ b/neat/population.py
@@ -28,7 +28,7 @@ class Population:
 
     def fitness_sharing(self):
         for i in range(self.pop_len):
-            # For now, fitness_sharing dosen't work
+            # For now, fitness_sharing doesn't work
             self.population[i].adjusted_fitness = self.population[i].fitness
             pass
         pass


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 600 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

`ruff --output-format=github` rapidly provides intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)
