### PR TITLE
ruff --extend-exclude=__main__.py

### DIFF
--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -16,4 +16,4 @@ jobs:
     - uses: actions/checkout@v4
     - run: pip install --user codespell[toml] ruff
     - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock,*.po"
-    - run: ruff --ignore=__main__.py --output-format=github --target-version=py38 .
+    - run: ruff --extend-exclude=__main__.py --output-format=github --target-version=py38 .

--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -16,4 +16,4 @@ jobs:
     - uses: actions/checkout@v4
     - run: pip install --user codespell[toml] ruff
     - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock,*.po"
-    - run: ruff --output-format=github --target-version=py38 .
+    - run: ruff --ignore=__main__.py --output-format=github --target-version=py38 .


### PR DESCRIPTION
Should this file be ignored because it is vendored in from elsewhere?